### PR TITLE
Make modalManager warn and report duplicate mount (don't crash)

### DIFF
--- a/src/Modals/ModalManager.js
+++ b/src/Modals/ModalManager.js
@@ -28,7 +28,10 @@ export class ModalManager extends React.Component<{}, State> {
 
     // Register as the global modal manager:
     if (globalModalManager != null) {
-      throw new Error('The ModalManager must only be mounted once')
+      const errorMessage = 'The ModalManager must only be mounted once'
+      console.warn(errorMessage)
+      const error = new Error(errorMessage)
+      global.bugsnag && global.bugsnag.notify(error)
     }
     globalModalManager = this
   }


### PR DESCRIPTION
The purpose of this task is to prevent the app from crashing when the ModalManager gets mounted twice. Instead we have told the app to warn us and send a BugSnag report.

Asana Task: https://app.asana.com/0/361770107085503/1112429530152836/f